### PR TITLE
Open API Swagger 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
 	compileOnly("org.projectlombok:lombok")
 	developmentOnly("org.springframework.boot:spring-boot-docker-compose")
 	runtimeOnly("com.h2database:h2")

--- a/src/main/java/com/tourapi/mandi/domain/user/controller/LoginController.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/controller/LoginController.java
@@ -1,22 +1,22 @@
 package com.tourapi.mandi.domain.user.controller;
 
-
-import com.tourapi.mandi.domain.user.UserExceptionStatus;
 import com.tourapi.mandi.domain.user.dto.LoginResponseDto;
 import com.tourapi.mandi.domain.user.dto.oauth.GoogleUserInfo;
 import com.tourapi.mandi.domain.user.service.GoogleService;
 import com.tourapi.mandi.domain.user.service.UserService;
-import com.tourapi.mandi.global.exception.Exception400;
 import com.tourapi.mandi.global.util.ApiUtils;
-import jakarta.servlet.http.HttpServletRequest;
+import com.tourapi.mandi.global.util.ApiUtils.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Optional;
-
+@Tag(name = "로그인 API 목록")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
@@ -25,10 +25,13 @@ public class LoginController {
     private final GoogleService googleService;
     private final UserService userService;
 
+    @Operation(summary = "구글 소셜 로그인")
     @PostMapping("/google/login")
-    public ResponseEntity<?> googleLogin(HttpServletRequest request) {
-        String token = Optional.of(request.getHeader("Google")).orElseThrow(
-                () -> new Exception400(UserExceptionStatus.GOOGLE_TOKEN_MISSING));
+    public ResponseEntity<ApiResult<LoginResponseDto>> googleLogin(
+            @NotBlank
+            @RequestHeader(value = "Google")
+            String token
+    ) {
         GoogleUserInfo userInfo = googleService.getGoogleUserInfo(token);
         LoginResponseDto resultDto = userService.socialLogin(userInfo);
         return ResponseEntity.ok(ApiUtils.success(resultDto));

--- a/src/main/java/com/tourapi/mandi/domain/user/controller/LoginController.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/controller/LoginController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
+@Validated
 public class LoginController {
 
     private final GoogleService googleService;

--- a/src/main/java/com/tourapi/mandi/domain/user/dto/LoginResponseDto.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/dto/LoginResponseDto.java
@@ -1,9 +1,13 @@
 package com.tourapi.mandi.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+@Schema(description = "로그인 응답 DTO")
 public record LoginResponseDto(
+        @Schema(description = "엑세스 토큰")
         String accessToken,
+        @Schema(description = "리프레시 토큰")
         String refreshToken
 ) {
     @Builder

--- a/src/main/java/com/tourapi/mandi/global/config/OpenAPIConfig.java
+++ b/src/main/java/com/tourapi/mandi/global/config/OpenAPIConfig.java
@@ -1,0 +1,18 @@
+package com.tourapi.mandi.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAPIConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("만디 API 문서")
+                        .version("1.0.0")
+                );
+    }
+}

--- a/src/main/java/com/tourapi/mandi/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tourapi/mandi/global/exception/GlobalExceptionHandler.java
@@ -11,10 +11,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
-import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import java.util.List;
 
@@ -51,6 +51,15 @@ public class GlobalExceptionHandler {
                 HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<?> handleMissingHeaderException(Exception ex) {
+        return new ResponseEntity<>(ApiUtils.error("필요한 Request 헤더 값이 없습니다.",
+                HttpStatus.BAD_REQUEST.value(),
+                "04004"),
+                HttpStatus.BAD_REQUEST);
+    }
+
+
 
     @ExceptionHandler({Exception400.class, Exception401.class, Exception403.class, Exception404.class})
     public ResponseEntity<?> clientException(ClientException exception) {
@@ -67,7 +76,6 @@ public class GlobalExceptionHandler {
 
         String errorText = String.format("Location: %s, Cause: %s", exception.getStackTrace()[0].toString(),
                 exception.getMessage());
-
         log.error(errorText);
         return new ResponseEntity<>(
                 ApiUtils.error("internal server", HttpStatus.INTERNAL_SERVER_ERROR.value(), "05000"),

--- a/src/main/java/com/tourapi/mandi/global/util/ApiUtils.java
+++ b/src/main/java/com/tourapi/mandi/global/util/ApiUtils.java
@@ -1,6 +1,8 @@
 package com.tourapi.mandi.global.util;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public class ApiUtils {
     public static <T> ApiResult<T> success(T response) {
         return new ApiResult<>(true, response, null);
@@ -10,6 +12,7 @@ public class ApiUtils {
         return new ApiResult<>(false, null, new ApiError(message, status, errorCode));
     }
 
+    @Schema(description = "정상 처리 시 응답 DTO")
     public record ApiResult<T>(
             boolean success,
             T response,
@@ -17,6 +20,7 @@ public class ApiUtils {
     ) {
     }
 
+    @Schema(description = "에러 발생 시 응답 DTO")
     public record ApiError(
             String message,
             int status,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,4 +45,10 @@ oauth2:
 access-jwt-secret-key: ${access-jwt-secret-key}
 refresh-jwt-secret-key: ${refresh-jwt-secret-key}
 
-
+springdoc:
+  swagger-ui:
+    operations-sorter: method
+    disable-swagger-default-url: true
+    path: /mandi/swagger-ui/index.html
+  api-docs:
+    path: /mandi/api-docs


### PR DESCRIPTION
## 개요
프론트 팀에게 API 문서 전달드리기 위해 Swagger를 적용했습니다.

## 관련 이슈
#3 

## 리뷰 요청 사항
- 로컬에서 실행 후 [localhost:8080/mandi/swagger-ui/index.html ](http://localhost:8080/mandi/swagger-ui/index.html) 접속 가능 여부 확인
- `LoginController`에서 수정된 부분 확인