### PR TITLE
배지 조회 기능 구현

### DIFF
--- a/src/main/java/com/tourapi/mandi/domain/badge/controller/BadgeController.java
+++ b/src/main/java/com/tourapi/mandi/domain/badge/controller/BadgeController.java
@@ -1,0 +1,33 @@
+package com.tourapi.mandi.domain.badge.controller;
+
+import com.tourapi.mandi.domain.badge.dto.BadgeListResponseDto;
+import com.tourapi.mandi.domain.badge.service.BadgeService;
+import com.tourapi.mandi.global.util.ApiUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "배지 API 목록")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/badges")
+@Validated
+public class BadgeController {
+
+    private final BadgeService badgeService;
+
+    @Operation(summary = "배지 목록 조회")
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiUtils.ApiResult<BadgeListResponseDto>> googleLogin(
+            @PathVariable("userId") Long userId
+    ) {
+        BadgeListResponseDto resultDto = badgeService.getUserBadges(userId);
+        return ResponseEntity.ok(ApiUtils.success(resultDto));
+    }
+}

--- a/src/main/java/com/tourapi/mandi/domain/badge/dto/BadgeListResponseDto.java
+++ b/src/main/java/com/tourapi/mandi/domain/badge/dto/BadgeListResponseDto.java
@@ -1,0 +1,15 @@
+package com.tourapi.mandi.domain.badge.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record BadgeListResponseDto(
+        @Schema(description = "전체 뱃지 개수")
+        int totalBadgeCount,
+        @Schema(description = "사용자 뱃지 개수")
+        int userBadgeCount,
+        @Schema(description = "사용자 뱃지 목록")
+        List<BadgeResponseDto> badges
+) {
+}

--- a/src/main/java/com/tourapi/mandi/domain/badge/dto/BadgeResponseDto.java
+++ b/src/main/java/com/tourapi/mandi/domain/badge/dto/BadgeResponseDto.java
@@ -1,0 +1,18 @@
+package com.tourapi.mandi.domain.badge.dto;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record BadgeResponseDto(
+        @Schema(description = "배지 id")
+        Long id,
+        @Schema(description = "배지 이름")
+        String name,
+        @Schema(description = "배지 획득 조건")
+        String requirements,
+        @Schema(description = "배지 이미지")
+        String imgUrl
+) {
+}

--- a/src/main/java/com/tourapi/mandi/domain/badge/entity/Badge.java
+++ b/src/main/java/com/tourapi/mandi/domain/badge/entity/Badge.java
@@ -1,0 +1,57 @@
+package com.tourapi.mandi.domain.badge.entity;
+
+
+import com.tourapi.mandi.global.util.AuditingEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "badge_tb")
+public class Badge extends AuditingEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "badge_id")
+    private Long badgeId;
+
+    @Column(length = 30, nullable = false, unique = true, name = "name")
+    private String name;
+
+    @Column(length = 100, nullable = false, name = "requirements")
+    private String requirements;
+
+    @Column(length = 512, nullable = false, name = "img_url")
+    private String imgUrl;
+
+    @Builder
+    public Badge(Long badgeId, String name, String requirements, String imgUrl) {
+        this.badgeId = badgeId;
+        this.name = name;
+        this.requirements = requirements;
+        this.imgUrl = imgUrl;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Badge other = (Badge) obj;
+        return Objects.equals(getBadgeId(), other.getBadgeId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getBadgeId());
+    }
+}

--- a/src/main/java/com/tourapi/mandi/domain/badge/entity/UserBadge.java
+++ b/src/main/java/com/tourapi/mandi/domain/badge/entity/UserBadge.java
@@ -1,0 +1,47 @@
+package com.tourapi.mandi.domain.badge.entity;
+
+import com.tourapi.mandi.domain.user.entity.User;
+import com.tourapi.mandi.global.util.AuditingEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "user_badge_tb")
+public class UserBadge extends AuditingEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_badge_id")
+    private Long badgeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "badge_id")
+    private Badge badge;
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        UserBadge other = (UserBadge) obj;
+        return Objects.equals(getBadgeId(), other.getBadgeId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getBadgeId());
+    }
+}

--- a/src/main/java/com/tourapi/mandi/domain/badge/repository/BadgeRepository.java
+++ b/src/main/java/com/tourapi/mandi/domain/badge/repository/BadgeRepository.java
@@ -1,0 +1,7 @@
+package com.tourapi.mandi.domain.badge.repository;
+
+import com.tourapi.mandi.domain.badge.entity.Badge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BadgeRepository extends JpaRepository<Badge, Long> {
+}

--- a/src/main/java/com/tourapi/mandi/domain/badge/repository/UserBadgeRepository.java
+++ b/src/main/java/com/tourapi/mandi/domain/badge/repository/UserBadgeRepository.java
@@ -1,0 +1,16 @@
+package com.tourapi.mandi.domain.badge.repository;
+
+import com.tourapi.mandi.domain.badge.entity.Badge;
+import com.tourapi.mandi.domain.badge.entity.UserBadge;
+import com.tourapi.mandi.domain.user.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
+
+    @Query("select ub.badge from UserBadge ub where ub.user = :user")
+    List<Badge> findAllByUser(@Param("user") User user);
+}

--- a/src/main/java/com/tourapi/mandi/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/tourapi/mandi/domain/badge/service/BadgeService.java
@@ -1,0 +1,44 @@
+package com.tourapi.mandi.domain.badge.service;
+
+import com.tourapi.mandi.domain.badge.dto.BadgeListResponseDto;
+import com.tourapi.mandi.domain.badge.dto.BadgeResponseDto;
+import com.tourapi.mandi.domain.badge.entity.Badge;
+import com.tourapi.mandi.domain.badge.repository.BadgeRepository;
+import com.tourapi.mandi.domain.badge.repository.UserBadgeRepository;
+import com.tourapi.mandi.domain.badge.util.BadgeMapper;
+import com.tourapi.mandi.domain.user.UserExceptionStatus;
+import com.tourapi.mandi.domain.user.entity.User;
+import com.tourapi.mandi.domain.user.repository.UserJpaRepository;
+import com.tourapi.mandi.global.exception.Exception404;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BadgeService {
+
+    private final UserJpaRepository userJpaRepository;
+    private final BadgeRepository badgeRepository;
+    private final UserBadgeRepository userBadgeRepository;
+
+    public BadgeListResponseDto getUserBadges(Long userId) {
+        User user = userJpaRepository.findById(userId)
+                .orElseThrow(() -> new Exception404(UserExceptionStatus.USER_NOT_FOUND));
+
+        List<Badge> allBadges = badgeRepository.findAll();
+        List<Badge> userBadges = userBadgeRepository.findAllByUser(user);
+        List<BadgeResponseDto> badges = new ArrayList<>();
+
+        for (final Badge badge : allBadges) {
+            badges.add(BadgeMapper.toBadgeResponseDto(badge, userBadges.contains(badge)));
+        }
+        return new BadgeListResponseDto(allBadges.size(), userBadges.size(), badges);
+    }
+}

--- a/src/main/java/com/tourapi/mandi/domain/badge/util/BadgeMapper.java
+++ b/src/main/java/com/tourapi/mandi/domain/badge/util/BadgeMapper.java
@@ -1,0 +1,24 @@
+package com.tourapi.mandi.domain.badge.util;
+
+import com.tourapi.mandi.domain.badge.dto.BadgeResponseDto;
+import com.tourapi.mandi.domain.badge.entity.Badge;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class BadgeMapper {
+
+    private static final String DEFAULT_IMG_URL = "DEFAULT_IMG_URL";
+
+    public static BadgeResponseDto toBadgeResponseDto(Badge badge, boolean isObtained) {
+        BadgeResponseDto.BadgeResponseDtoBuilder badgeBuilder = BadgeResponseDto.builder()
+                .id(badge.getBadgeId())
+                .name(badge.getName())
+                .requirements(badge.getRequirements());
+
+        if (isObtained) {
+            return badgeBuilder.imgUrl(badge.getImgUrl()).build();
+        }
+        return badgeBuilder.imgUrl(DEFAULT_IMG_URL).build();
+    }
+}

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -1,0 +1,26 @@
+INSERT INTO badge_tb(img_url, name, requirements, created_at, last_modified_at)
+VALUES ('test_img01', 'badge01', 'conditions01', now(), now());
+
+INSERT INTO badge_tb(img_url, name, requirements, created_at, last_modified_at)
+VALUES ('test_img02', 'badge02', 'conditions02', now(), now());
+
+INSERT INTO badge_tb(img_url, name, requirements, created_at, last_modified_at)
+VALUES ('test_img03', 'badge03', 'conditions03', now(), now());
+
+INSERT INTO badge_tb(img_url, name, requirements, created_at, last_modified_at)
+VALUES ('test_img04', 'badge04', 'conditions04', now(), now());
+
+INSERT INTO badge_tb(img_url, name, requirements, created_at, last_modified_at)
+VALUES ('test_img05', 'badge05', 'conditions05', now(), now());
+
+INSERT INTO badge_tb(img_url, name, requirements, created_at, last_modified_at)
+VALUES ('test_img06', 'badge06', 'conditions06', now(), now());
+
+INSERT INTO user_tb(description, email, img_url, nickname, password, provider, role, created_at, last_modified_at)
+VALUES ( 'hello world', 'lsh901673@gmail.com', '', 'lsh', '1234', 'PROVIDER_GOOGLE', 'ROLE_USER', now(), now());
+
+INSERT INTO user_badge_tb(user_id, badge_id, created_at, last_modified_at)
+VALUES(1, 1, now(), now());
+
+INSERT INTO user_badge_tb(user_id, badge_id, created_at, last_modified_at)
+VALUES(1, 2, now(), now());


### PR DESCRIPTION
## 개요
1. 초기 데이터 구성을 위해 submodule과 sql script를 작성하였습니다.
2. 사용자가 보유하고 있는 배지를 조회하는 기능을 구현했습니다.
    - 프로젝트의 ERD를 참고하여 배지와 관련된 대한 Entitiy를 추가했습니다.
    - 사용자가 획득하지 못한 뱃지는 기본 이미지의 URL을 반환하도록 로직을 작성하였습니다.

### submodule

> 링크: https://github.com/kakao-travel-mandi/mandi-backend-config/commit/f3f8770764156e6895c147c6290a30648d65f380

![image](https://github.com/user-attachments/assets/e71c4708-7e22-4232-b65a-58aceeffff92)

## 관련 이슈
#11 

## 참고 사항

- 