### PR TITLE
s3을 활용한 프로필사진 업로드 구현 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,8 @@ dependencies {
 	testImplementation("io.projectreactor:reactor-test")
 	testImplementation("org.springframework.security:spring-security-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-
+	// AWS S3
+	implementation ("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/tourapi/mandi/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/tourapi/mandi/domain/badge/service/BadgeService.java
@@ -10,9 +10,11 @@ import com.tourapi.mandi.domain.user.UserExceptionStatus;
 import com.tourapi.mandi.domain.user.entity.User;
 import com.tourapi.mandi.domain.user.repository.UserJpaRepository;
 import com.tourapi.mandi.global.exception.Exception404;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +29,7 @@ public class BadgeService {
     private final UserJpaRepository userJpaRepository;
     private final BadgeRepository badgeRepository;
     private final UserBadgeRepository userBadgeRepository;
-
+    @Transactional(readOnly=true)
     public BadgeListResponseDto getUserBadges(Long userId) {
         User user = userJpaRepository.findById(userId)
                 .orElseThrow(() -> new Exception404(UserExceptionStatus.USER_NOT_FOUND));

--- a/src/main/java/com/tourapi/mandi/domain/user/UserExceptionStatus.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/UserExceptionStatus.java
@@ -13,7 +13,7 @@ public enum UserExceptionStatus implements BaseExceptionStatus {
     REFRESH_TOKEN_EXPIRED("유효기간이 만료된 토큰입니다.", 400, "14002"),
     GOOGLE_TOKEN_MISSING("구글 토큰를 입력하지 않았습니다.", 400, "14003"),
     USER_NOT_FOUND("회원이 존재하지 않습니다", 404, "14040"),
-    NICKNAME_ALREADY_EXISTS("이미 사용 중인 닉네임입니다. 다른 닉네임을 입력하세요.", 409, "14041"),
+    NICKNAME_ALREADY_EXISTS("이미 사용 중인 닉네임입니다. 다른 닉네임을 입력하세요.", 409, "14090"),
     GOOGLE_API_CONNECTION_ERROR("구글 API 연동 중 문제가 발생했습니다", 500, "15000");
 
     @Getter

--- a/src/main/java/com/tourapi/mandi/domain/user/controller/LoginController.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/controller/LoginController.java
@@ -2,10 +2,12 @@ package com.tourapi.mandi.domain.user.controller;
 
 import com.tourapi.mandi.domain.user.dto.LoginResponseDto;
 import com.tourapi.mandi.domain.user.dto.NicknameValidationRequestDto;
+import com.tourapi.mandi.domain.user.dto.ProfileImageChangeRequestDto;
 import com.tourapi.mandi.domain.user.dto.SignupRequestDto;
 import com.tourapi.mandi.domain.user.dto.oauth.GoogleUserInfo;
 import com.tourapi.mandi.domain.user.service.GoogleService;
 import com.tourapi.mandi.domain.user.service.UserService;
+import com.tourapi.mandi.global.security.CustomUserDetails;
 import com.tourapi.mandi.global.util.ApiUtils;
 import com.tourapi.mandi.global.util.ApiUtils.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +16,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -62,5 +65,20 @@ public class LoginController {
             @RequestBody @Valid NicknameValidationRequestDto requestDto
     ) {
         return ResponseEntity.ok(ApiUtils.success(userService.checkNicknameDuplication(requestDto)));
+    }
+
+
+
+    @Operation(summary = "프로필 사진 변경")
+    @PostMapping("/change-profile")
+    public ResponseEntity<ApiResult<String>> changeProfileImage(
+            @RequestBody @Valid ProfileImageChangeRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+
+        System.out.println(userDetails.getUsername());
+        System.out.println(userDetails.user().toString());
+        System.out.println("시발아");
+        return ResponseEntity.ok(ApiUtils.success(userService.changeProfileImage(requestDto,userDetails.user())));
     }
 }

--- a/src/main/java/com/tourapi/mandi/domain/user/dto/NicknameValidationRequestDto.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/dto/NicknameValidationRequestDto.java
@@ -1,6 +1,7 @@
 package com.tourapi.mandi.domain.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
@@ -9,6 +10,7 @@ public record NicknameValidationRequestDto(
         @Schema(description = "닉네임")
         @Size(min = 2, max = 10, message = "닉네임은 2~10자 사이여야 합니다.")
         @Pattern(regexp = "^[a-zA-Z0-9가-힣]*$", message = "닉네임은 영문, 숫자, 한글만 사용 가능합니다.")
+        @NotBlank(message = "nickname필드값이 없습니다.")
         String nickname
 ) {
 }

--- a/src/main/java/com/tourapi/mandi/domain/user/dto/ProfileImageChangeRequestDto.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/dto/ProfileImageChangeRequestDto.java
@@ -1,0 +1,2 @@
+package com.tourapi.mandi.domain.user.dto;public class ProfileImageChangeRequestDto {
+}

--- a/src/main/java/com/tourapi/mandi/domain/user/dto/ProfileImageChangeRequestDto.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/dto/ProfileImageChangeRequestDto.java
@@ -1,2 +1,15 @@
-package com.tourapi.mandi.domain.user.dto;public class ProfileImageChangeRequestDto {
+package com.tourapi.mandi.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "프로필 사진 변경 요청 DTO")
+public record ProfileImageChangeRequestDto (
+
+        @Schema(description = "Base64로 인코딩된 사진데이터")
+        @NotBlank(message = "Base64EncodedImage필드값이 없습니다.")
+        String Base64EncodedImage
+
+) {
+
 }

--- a/src/main/java/com/tourapi/mandi/domain/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/dto/SignupRequestDto.java
@@ -10,6 +10,7 @@ public record SignupRequestDto(
         @Size(min = 2, max = 10, message = "닉네임은 2~10자 사이여야 합니다.")
         @Pattern(regexp = "^[a-zA-Z0-9가-힣]*$", message = "닉네임은 영문, 숫자, 한글만 사용 가능합니다.")
         String nickname,
+
         @Schema(description = "한줄소개")
         @Size(max = 40, message = "한줄소개는 공백 포함 40자를 넘을 수 없습니다.")
         String description

--- a/src/main/java/com/tourapi/mandi/domain/user/entity/User.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/entity/User.java
@@ -4,10 +4,7 @@ import com.tourapi.mandi.domain.user.entity.constant.Provider;
 import com.tourapi.mandi.domain.user.entity.constant.Role;
 import com.tourapi.mandi.global.util.AuditingEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.Objects;
 
@@ -44,6 +41,7 @@ public class User extends AuditingEntity {
     @Column(length = 40, name = "description")
     private String description;
 
+    @Setter
     @Column(length = 512, name = "img_url")
     private String imgUrl;
 

--- a/src/main/java/com/tourapi/mandi/domain/user/service/UserService.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/service/UserService.java
@@ -51,8 +51,8 @@ public class UserService {
             String accessToken = JwtProvider.create(user);
             String refreshToken = JwtProvider.createRefreshToken(user);
 
-            tokenService.save(refreshToken, accessToken, user);
-            return new LoginResponseDto(refreshToken,accessToken,true);
+            tokenService.save(accessToken, refreshToken, user);
+            return new LoginResponseDto(accessToken,refreshToken,true);
 
         }
         //유저정보 없을경우 => 처음 가입하는 유저
@@ -74,9 +74,9 @@ public class UserService {
         //토큰 만들어서 리턴
             String accessToken = JwtProvider.create(user);
             String refreshToken = JwtProvider.createRefreshToken(user);
-            tokenService.save(refreshToken, accessToken, user);
+            tokenService.save(accessToken, refreshToken, user);
 
-            return new LoginResponseDto(refreshToken,accessToken,true);
+            return new LoginResponseDto(accessToken,refreshToken,true);
 
         }
 

--- a/src/main/java/com/tourapi/mandi/domain/user/service/UserService.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/service/UserService.java
@@ -40,7 +40,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final UserJpaRepository userJpaRepository;
     private final TokenService tokenService;
-
+    private final String defaultImageUrl ="https://mandi-image.s3.ap-northeast-2.amazonaws.com/image/default.png";
 
     public LoginResponseDto socialLogin(OauthUserInfo userInfo) {
         Optional<User> userOptional = userJpaRepository.findByEmail(userInfo.email());
@@ -69,6 +69,7 @@ public class UserService {
                     .provider(userInfo.provider())
                     .nickname(signupRequestDto.nickname())
                     .description(signupRequestDto.description())
+                    .imgUrl(defaultImageUrl)
                     .build();
             userJpaRepository.save(user);
         //토큰 만들어서 리턴

--- a/src/main/java/com/tourapi/mandi/global/config/JpaConfig.java
+++ b/src/main/java/com/tourapi/mandi/global/config/JpaConfig.java
@@ -1,5 +1,6 @@
 package com.tourapi.mandi.global.config;
 
+
 import com.tourapi.mandi.global.security.CustomUserDetails;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/tourapi/mandi/global/config/S3Config.java
+++ b/src/main/java/com/tourapi/mandi/global/config/S3Config.java
@@ -6,7 +6,12 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
+
+@Profile({ "local"})
+@Configuration
 public class S3Config {
 
     @Value("${cloud.aws.credentials.access-key}")

--- a/src/main/java/com/tourapi/mandi/global/config/S3Config.java
+++ b/src/main/java/com/tourapi/mandi/global/config/S3Config.java
@@ -1,2 +1,32 @@
-package com.tourapi.mandi.global.config;public class S3Config {
+package com.tourapi.mandi.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+
 }

--- a/src/main/java/com/tourapi/mandi/global/config/S3Config.java
+++ b/src/main/java/com/tourapi/mandi/global/config/S3Config.java
@@ -1,0 +1,2 @@
+package com.tourapi.mandi.global.config;public class S3Config {
+}

--- a/src/main/java/com/tourapi/mandi/global/redis/entity/BlackListToken.java
+++ b/src/main/java/com/tourapi/mandi/global/redis/entity/BlackListToken.java
@@ -1,2 +1,45 @@
-package com.tourapi.mandi.global.redis.entity;public class BlackListToken {
+package com.tourapi.mandi.global.redis.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+@RedisHash(value = "BlackList")
+@Getter
+public class BlackListToken {
+
+    @Id
+    private String accessToken;
+
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private Long expiration;
+
+    @Builder
+    public BlackListToken(String accessToken, Long expiration) {
+        this.accessToken = accessToken;
+        this.expiration = expiration;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        BlackListToken that = (BlackListToken)obj;
+        return Objects.equals(getAccessToken(), that.getAccessToken());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getAccessToken());
+    }
+
 }

--- a/src/main/java/com/tourapi/mandi/global/redis/entity/BlackListToken.java
+++ b/src/main/java/com/tourapi/mandi/global/redis/entity/BlackListToken.java
@@ -1,0 +1,2 @@
+package com.tourapi.mandi.global.redis.entity;public class BlackListToken {
+}

--- a/src/main/java/com/tourapi/mandi/global/redis/repository/BlackListTokenRepository.java
+++ b/src/main/java/com/tourapi/mandi/global/redis/repository/BlackListTokenRepository.java
@@ -1,2 +1,10 @@
-package com.tourapi.mandi.global.redis.repository;public interface BlackListTokenRepository {
+package com.tourapi.mandi.global.redis.repository;
+
+import com.tourapi.mandi.global.redis.entity.BlackListToken;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface BlackListTokenRepository  extends CrudRepository<BlackListToken, String> {
+    Optional<BlackListToken> findById(String accessToken);
 }

--- a/src/main/java/com/tourapi/mandi/global/redis/repository/BlackListTokenRepository.java
+++ b/src/main/java/com/tourapi/mandi/global/redis/repository/BlackListTokenRepository.java
@@ -1,0 +1,2 @@
+package com.tourapi.mandi.global.redis.repository;public interface BlackListTokenRepository {
+}

--- a/src/main/java/com/tourapi/mandi/global/redis/service/BlackListTokenService.java
+++ b/src/main/java/com/tourapi/mandi/global/redis/service/BlackListTokenService.java
@@ -1,2 +1,32 @@
-package com.tourapi.mandi.global.redis.service;public class BlackListTokenService {
+package com.tourapi.mandi.global.redis.service;
+import com.tourapi.mandi.global.exception.Exception403;
+import com.tourapi.mandi.global.redis.RedisExceptionStatus;
+import com.tourapi.mandi.global.redis.entity.BlackListToken;
+import com.tourapi.mandi.global.redis.repository.BlackListTokenRepository;
+import com.tourapi.mandi.global.security.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BlackListTokenService {
+
+        private final BlackListTokenRepository blackListTokenRepository;
+
+        public void save(String accessToken) {
+        Long remainTime = JwtProvider.getRemainExpiration(accessToken);
+        BlackListToken blackListToken = BlackListToken.builder()
+                .accessToken(accessToken)
+                .expiration(remainTime)
+                .build();
+
+        blackListTokenRepository.save(blackListToken);
+    }
+
+        public void validAccessToken(String accessToken) {
+        if (blackListTokenRepository.existsById(accessToken)) {
+            throw new Exception403(RedisExceptionStatus.BLACKLIST_TOKEN);
+        }
+    }
+
 }

--- a/src/main/java/com/tourapi/mandi/global/redis/service/BlackListTokenService.java
+++ b/src/main/java/com/tourapi/mandi/global/redis/service/BlackListTokenService.java
@@ -1,0 +1,2 @@
+package com.tourapi.mandi.global.redis.service;public class BlackListTokenService {
+}

--- a/src/main/java/com/tourapi/mandi/global/security/CustomUserDetails.java
+++ b/src/main/java/com/tourapi/mandi/global/security/CustomUserDetails.java
@@ -11,11 +11,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-@RequiredArgsConstructor
-@Getter
-public class CustomUserDetails implements UserDetails {
 
-    private final User user;
+public record CustomUserDetails(User user) implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/tourapi/mandi/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/tourapi/mandi/global/security/CustomUserDetailsService.java
@@ -1,0 +1,2 @@
+package com.tourapi.mandi.global.security;public class CustomUserDetailsService {
+}

--- a/src/main/java/com/tourapi/mandi/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/tourapi/mandi/global/security/CustomUserDetailsService.java
@@ -1,2 +1,23 @@
-package com.tourapi.mandi.global.security;public class CustomUserDetailsService {
+package com.tourapi.mandi.global.security;
+
+import com.tourapi.mandi.domain.user.UserExceptionStatus;
+import com.tourapi.mandi.domain.user.repository.UserJpaRepository;
+import com.tourapi.mandi.global.exception.Exception404;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return new CustomUserDetails(userJpaRepository.findByEmail(email)
+                .orElseThrow(() -> new Exception404(UserExceptionStatus.USER_NOT_FOUND)));
+    }
 }

--- a/src/main/java/com/tourapi/mandi/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tourapi/mandi/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,2 @@
+package com.tourapi.mandi.global.security;public class JwtAuthenticationFilter {
+}

--- a/src/main/java/com/tourapi/mandi/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tourapi/mandi/global/security/JwtAuthenticationFilter.java
@@ -1,2 +1,79 @@
-package com.tourapi.mandi.global.security;public class JwtAuthenticationFilter {
+package com.tourapi.mandi.global.security;
+
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.tourapi.mandi.domain.user.entity.User;
+import com.tourapi.mandi.domain.user.entity.constant.Role;
+import com.tourapi.mandi.global.redis.service.BlackListTokenService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
+    private final BlackListTokenService blackListTokenService;
+
+    public JwtAuthenticationFilter(
+            AuthenticationManager authenticationManager, BlackListTokenService blackListTokenService) {
+        super(authenticationManager);
+        this.blackListTokenService = blackListTokenService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        String jwt = request.getHeader(JwtProvider.HEADER);
+
+        if (jwt == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        if (!jwt.startsWith("Bearer")) {
+            log.error("잘못된 토큰");
+            throw new JWTDecodeException("토큰 형식이 잘못되었습니다.");
+        }
+
+        // accessToken이 블랙 리스트에 있는지 확인
+        blackListTokenService.validAccessToken(jwt);
+
+        try {
+            DecodedJWT decodedJwt = JwtProvider.verify(jwt);
+            Long id = decodedJwt.getClaim("id").asLong();
+            String role = decodedJwt.getClaim("role").asString();
+            User user = User.builder().userId(id).role(Role.valueOf(role)).build();
+            CustomUserDetails myUserDetails = new CustomUserDetails(user);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            myUserDetails,
+                            myUserDetails.getPassword(),
+                            myUserDetails.getAuthorities()
+                    );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("디버그 : 인증 객체 만들어짐");
+        } catch (SignatureVerificationException sve) {
+            log.error("토큰 검증 실패");
+            throw new JWTVerificationException("토큰 검증에 실패했습니다.");
+        } catch (TokenExpiredException tee) {
+            log.error("토큰 만료됨");
+        } catch (JWTDecodeException jde) {
+            log.error("잘못된 토큰");
+            throw new JWTDecodeException("토큰 형식이 잘못되었습니다.");
+        } finally {
+            chain.doFilter(request, response);
+        }
+    }
+
 }

--- a/src/main/java/com/tourapi/mandi/global/security/JwtExceptionFilter.java
+++ b/src/main/java/com/tourapi/mandi/global/security/JwtExceptionFilter.java
@@ -1,0 +1,2 @@
+package com.tourapi.mandi.global.security;public class JwtExceptionFilter {
+}

--- a/src/main/java/com/tourapi/mandi/global/security/JwtExceptionFilter.java
+++ b/src/main/java/com/tourapi/mandi/global/security/JwtExceptionFilter.java
@@ -1,2 +1,54 @@
-package com.tourapi.mandi.global.security;public class JwtExceptionFilter {
+package com.tourapi.mandi.global.security;
+
+import com.auth0.jwt.exceptions.JWTCreationException;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tourapi.mandi.global.exception.Exception403;
+import com.tourapi.mandi.global.util.ApiUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private static final ObjectMapper om = new ObjectMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JWTVerificationException | JWTCreationException | Exception403 e) {
+            setForbiddenResponse(request, response, e);
+        }
+    }
+
+    private void setJwtExceptionResponse(HttpServletRequest request, HttpServletResponse response, Throwable exception)
+            throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getOutputStream()
+                .write(om.writeValueAsBytes(
+                        ApiUtils.error(exception.getMessage(),
+                                HttpStatus.UNAUTHORIZED.value(),
+                                "04010")));
+    }
+
+    private void setForbiddenResponse(HttpServletRequest request, HttpServletResponse response, Throwable exception)
+            throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.getOutputStream()
+                .write(om.writeValueAsBytes(
+                        ApiUtils.error(exception.getMessage(),
+                                HttpStatus.FORBIDDEN.value(),
+                                "04030")));
+    }
+
 }

--- a/src/main/java/com/tourapi/mandi/global/security/SecurityConfig.java
+++ b/src/main/java/com/tourapi/mandi/global/security/SecurityConfig.java
@@ -1,8 +1,15 @@
 package com.tourapi.mandi.global.security;
 
+import com.tourapi.mandi.global.exception.Exception401;
+import com.tourapi.mandi.global.exception.Exception403;
+import com.tourapi.mandi.global.redis.service.BlackListTokenService;
+import com.tourapi.mandi.global.util.FilterResponseUtils;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.*;
@@ -11,58 +18,70 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final BlackListTokenService blackListTokenService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
+    // AuthenticationManager 빈을 명시적으로 등록합니다.
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
 
         // CSRF 해제
-        http.csrf(CsrfConfigurer::disable);
+        http.csrf(AbstractHttpConfigurer::disable);
 
         // iframe 거부
-           http.headers(headers -> headers
-                .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin // 기본적으로 같은 origin에서만 iframe 허용
-
-                )
-        );
+        http.headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
 
         // cors 재설정
-        http.cors(corsConfigurer ->
-                corsConfigurer.configurationSource(configurationSource())
-        );
+        http.cors(corsConfigurer -> corsConfigurer.configurationSource(configurationSource()));
 
         // jSessionId 사용 거부
-        http.sessionManagement(sessionManagementConfigurer ->
-                sessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-        );
+        http.sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         // form 로그인 해제
-        http.formLogin(FormLoginConfigurer::disable);
+        http.formLogin(AbstractHttpConfigurer::disable);
 
-        // 로그인 인증창 비활성화
-        http.httpBasic(HttpBasicConfigurer::disable);
+        // 로그인 인증창 비활성화 (HTTP Basic 비활성화)
+        http.httpBasic(AbstractHttpConfigurer::disable);
 
+        // 커스텀 필터 적용
+        http.addFilter(new JwtAuthenticationFilter(authenticationManager, blackListTokenService));
+        http.addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class);
 
-        http
-                .authorizeHttpRequests(authorize -> authorize
-                        .anyRequest().permitAll()
-                )
-                .csrf(AbstractHttpConfigurer::disable)
-                .cors(cors -> cors.configurationSource(configurationSource()))
-        ;
+        // 인증 실패 처리
+        http.exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint((request, response, authException) -> FilterResponseUtils.unAuthorized(response, new Exception401(SecurityExceptionStatus.UNAUTHORIZED))));
 
+        // 권한 실패 처리
+        http.exceptionHandling(exceptionHandling -> exceptionHandling.accessDeniedHandler((request, response, authException) -> FilterResponseUtils.forbidden(response, new Exception403(SecurityExceptionStatus.FORBIDDEN))));
+
+        // 인증, 권한 필터 설정
+        http.authorizeHttpRequests(authorize -> authorize
+                .requestMatchers(
+                        new AntPathRequestMatcher("/auth/google/login"),
+                        new AntPathRequestMatcher("/auth/google/signup"),
+                        new AntPathRequestMatcher("/auth/check-nickname"))
+                .permitAll()
+                .requestMatchers(new AntPathRequestMatcher("/auth/change-profile"))
+                .authenticated()
+                .anyRequest().permitAll());
 
         return http.build();
     }
@@ -71,13 +90,16 @@ public class SecurityConfig {
     public CorsConfigurationSource configurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedHeader("*");
-        configuration.addAllowedMethod("*"); // GET, POST, UPDATE, DELETE 모두 허용
-        configuration.addAllowedOriginPattern("*"); // 모든 IP 주소 허용
-        configuration.setAllowCredentials(true); // 클라이언트에게 쿠키 요청 허용
-        configuration.addExposedHeader("Authorization"); // 클라이언트에게 Authorization 헤더 접근 허용
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedOriginPattern("*");
+        configuration.setAllowCredentials(true);
+        configuration.addExposedHeader("Authorization");
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
 }
+
+
+

--- a/src/main/java/com/tourapi/mandi/global/security/SecurityExceptionStatus.java
+++ b/src/main/java/com/tourapi/mandi/global/security/SecurityExceptionStatus.java
@@ -1,2 +1,16 @@
-package com.tourapi.mandi.global.security;public enum SecurityExceptionStatus {
+package com.tourapi.mandi.global.security;
+
+import com.tourapi.mandi.global.exception.BaseExceptionStatus;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+@Getter
+@RequiredArgsConstructor
+public enum SecurityExceptionStatus implements BaseExceptionStatus {
+    UNAUTHORIZED("인증되지 않았습니다.", 401, "04010"),
+    FORBIDDEN("권한이 없습니다.", 403, "04030");
+
+    private final String message;
+    private final int status;
+    private final String errorCode;
+
 }

--- a/src/main/java/com/tourapi/mandi/global/security/SecurityExceptionStatus.java
+++ b/src/main/java/com/tourapi/mandi/global/security/SecurityExceptionStatus.java
@@ -1,0 +1,2 @@
+package com.tourapi.mandi.global.security;public enum SecurityExceptionStatus {
+}

--- a/src/main/java/com/tourapi/mandi/global/util/FilterResponseUtils.java
+++ b/src/main/java/com/tourapi/mandi/global/util/FilterResponseUtils.java
@@ -1,0 +1,2 @@
+package com.tourapi.mandi.global.util;public class FilterResponseUtils {
+}

--- a/src/main/java/com/tourapi/mandi/global/util/FilterResponseUtils.java
+++ b/src/main/java/com/tourapi/mandi/global/util/FilterResponseUtils.java
@@ -1,2 +1,27 @@
-package com.tourapi.mandi.global.util;public class FilterResponseUtils {
+package com.tourapi.mandi.global.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tourapi.mandi.global.exception.Exception401;
+import com.tourapi.mandi.global.exception.Exception403;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+
+public class FilterResponseUtils {
+
+        private static final ObjectMapper om = new ObjectMapper();
+
+        public static void unAuthorized(HttpServletResponse response, Exception401 exception) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(exception.status().value());
+        response.getWriter().println(om.writeValueAsString(exception.body()));
+    }
+
+        public static void forbidden(HttpServletResponse response, Exception403 exception) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(exception.status().value());
+        response.getWriter().println(om.writeValueAsString(exception.body()));
+    }
+
 }

--- a/src/main/java/com/tourapi/mandi/global/util/S3Client.java
+++ b/src/main/java/com/tourapi/mandi/global/util/S3Client.java
@@ -1,0 +1,2 @@
+package com.tourapi.mandi.global.util;public class S3Client {
+}

--- a/src/main/java/com/tourapi/mandi/global/util/S3Client.java
+++ b/src/main/java/com/tourapi/mandi/global/util/S3Client.java
@@ -1,2 +1,0 @@
-package com.tourapi.mandi.global.util;public class S3Client {
-}

--- a/src/main/java/com/tourapi/mandi/global/util/S3ImageClient.java
+++ b/src/main/java/com/tourapi/mandi/global/util/S3ImageClient.java
@@ -26,12 +26,12 @@ public class S3ImageClient {
 
     public String base64ImageToS3(String base64Data) {
         try {
-            byte[] byteImage = java.util.Base64.getDecoder().decode(base64Data);
 
+            byte[] byteImage = java.util.Base64.getDecoder().decode(base64Data);
             ByteArrayInputStream imageInputStream = getValidImageInputStream(byteImage);
 
             // AWS S3 저장 로직
-            String fileName = "image/" + UUID.randomUUID().toString();
+            String fileName = "image/" + UUID.randomUUID();
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentType("image/png");
             metadata.setContentLength(byteImage.length);
@@ -40,10 +40,10 @@ public class S3ImageClient {
             amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, imageInputStream, metadata));
             return amazonS3Client.getUrl(bucket, fileName).toString();
         } catch (IllegalArgumentException e) {
-            //base64로 인코딩된 이미지파일이 아닐경우, 이미지Url인지 확인
-            if (isValidImageUrl(base64Data)) {
-                return base64Data;
-            }
+//            //base64로 인코딩된 이미지파일이 아닐경우, 이미지Url인지 확인
+//            if (isValidImageUrl(base64Data)) {
+//                return base64Data;
+//            }
             throw new Exception400(UtilExceptionStatus.NOT_BASE64_DATA);
         }
     }
@@ -52,7 +52,6 @@ public class S3ImageClient {
     private ByteArrayInputStream getValidImageInputStream(byte[] byteImage) {
 
         ByteArrayInputStream imageInputStream = new ByteArrayInputStream(byteImage);
-
         try {
             BufferedImage image = ImageIO.read(imageInputStream);
 
@@ -68,21 +67,21 @@ public class S3ImageClient {
         return imageInputStream;
     }
 
-    private Boolean isValidImageUrl(String imgUrlString) {
-
-        try {
-            URL imgUrl = new URL(imgUrlString);
-            BufferedImage image = ImageIO.read(imgUrl);
-
-            // image인지 체크하는 로직
-            if (image == null) {
-                throw new Exception400(UtilExceptionStatus.IMAGE_URL_INVALID);
-            }
-        } catch (IOException exception) {
-            throw new Exception400(UtilExceptionStatus.IMAGE_UNREADABLE_URL);
-        }
-
-        return true;
-    }
+//    private Boolean isValidImageUrl(String imgUrlString) {
+//
+//        try {
+//            URL imgUrl = new URL(imgUrlString);
+//            BufferedImage image = ImageIO.read(imgUrl);
+//
+//            // image인지 체크하는 로직
+//            if (image == null) {
+//                throw new Exception400(UtilExceptionStatus.IMAGE_URL_INVALID);
+//            }
+//        } catch (IOException exception) {
+//            throw new Exception400(UtilExceptionStatus.IMAGE_UNREADABLE_URL);
+//        }
+//
+//        return true;
+//    }
 
 }

--- a/src/main/java/com/tourapi/mandi/global/util/S3ImageClient.java
+++ b/src/main/java/com/tourapi/mandi/global/util/S3ImageClient.java
@@ -1,0 +1,89 @@
+package com.tourapi.mandi.global.util;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+
+
+@Component
+@RequiredArgsConstructor
+public class S3Client {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3Client amazonS3Client;
+
+    public String base64ImageToS3(String base64Data) {
+        try {
+            byte[] byteImage = java.util.Base64.getDecoder().decode(base64Data);
+
+            InputStream imageInputStream = getValidImageInputStream(byteImage);
+
+            // AWS S3 저장 로직
+            String fileName = "image/" + UUID.randomUUID().toString();
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType("image/png");
+            metadata.setContentLength(byteImage.length);
+            metadata.setCacheControl("public, max-age=31536000");
+
+            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, imageInputStream, metadata));
+            return amazonS3Client.getUrl(bucket, fileName).toString();
+        } catch (IllegalArgumentException e) {
+            //base64로 인코딩된 이미지파일이 아닐경우, 이미지Url인지 확인
+            if (isValidImageUrl(base64Data)) {
+                return base64Data;
+            }
+            throw new Exception400(UtilExceptionStatus.NOT_BASE64_DATA);
+        }
+    }
+
+    public String base64ImageToS3(String base64Data, String bookmarkLink) {
+        if (base64Data == null) {
+            return jsoupUtils.getImgUrl(bookmarkLink);
+        }
+
+        return base64ImageToS3(base64Data);
+    }
+
+    private ByteArrayInputStream getValidImageInputStream(byte[] byteImage) {
+
+        ByteArrayInputStream imageInputStream = new ByteArrayInputStream(byteImage);
+
+        try {
+            BufferedImage image = ImageIO.read(imageInputStream);
+
+            // image인지 체크하는 로직
+            if (image == null) {
+                throw new Exception400(UtilExceptionStatus.IMAGE_INVALID_DATA);
+            } else {
+                imageInputStream.reset();
+            }
+        } catch (IOException exception) {
+            throw new Exception400(UtilExceptionStatus.IMAGE_UNREADABLE_DATA);
+        }
+        return imageInputStream;
+    }
+
+    private Boolean isValidImageUrl(String imgUrlString) {
+
+        try {
+            URL imgUrl = new URL(imgUrlString);
+            BufferedImage image = ImageIO.read(imgUrl);
+
+            // image인지 체크하는 로직
+            if (image == null) {
+                throw new Exception400(UtilExceptionStatus.IMAGE_URL_INVALID);
+            }
+        } catch (IOException exception) {
+            throw new Exception400(UtilExceptionStatus.IMAGE_UNREADABLE_URL);
+        }
+
+        return true;
+    }
+
+}

--- a/src/main/java/com/tourapi/mandi/global/util/S3ImageClient.java
+++ b/src/main/java/com/tourapi/mandi/global/util/S3ImageClient.java
@@ -1,17 +1,23 @@
 package com.tourapi.mandi.global.util;
 
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.tourapi.mandi.global.exception.Exception400;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.convert.ReadingConverter;
 import org.springframework.stereotype.Component;
-
-import java.io.InputStream;
+import java.net.URL;
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.UUID;
 
 
 @Component
 @RequiredArgsConstructor
-public class S3Client {
+public class S3ImageClient {
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -22,7 +28,7 @@ public class S3Client {
         try {
             byte[] byteImage = java.util.Base64.getDecoder().decode(base64Data);
 
-            InputStream imageInputStream = getValidImageInputStream(byteImage);
+            ByteArrayInputStream imageInputStream = getValidImageInputStream(byteImage);
 
             // AWS S3 저장 로직
             String fileName = "image/" + UUID.randomUUID().toString();
@@ -42,13 +48,6 @@ public class S3Client {
         }
     }
 
-    public String base64ImageToS3(String base64Data, String bookmarkLink) {
-        if (base64Data == null) {
-            return jsoupUtils.getImgUrl(bookmarkLink);
-        }
-
-        return base64ImageToS3(base64Data);
-    }
 
     private ByteArrayInputStream getValidImageInputStream(byte[] byteImage) {
 

--- a/src/main/java/com/tourapi/mandi/global/util/UtilExceptionStatus.java
+++ b/src/main/java/com/tourapi/mandi/global/util/UtilExceptionStatus.java
@@ -8,13 +8,13 @@ import lombok.RequiredArgsConstructor;
 public enum UtilExceptionStatus implements BaseExceptionStatus {
 
     NOT_BASE64_DATA("Base64 형식이 아닙니다.", 400, "04004"),
-    IMAGE_INVALID_DATA("유효하지 않은 이미지 데이터입니다.", 400, "04005"),
+    IMAGE_INVALID_DATA("유효하지 않은 이미지 데이터이거나, 이미지 데이터가 아닙니다.", 400, "04005"),
 
-    IMAGE_UNREADABLE_DATA("이미지가 손상되었거나 읽을 수 없는 형식입니다.", 400, "04006"),
+    IMAGE_UNREADABLE_DATA("이미지가 손상되었거나 읽을 수 없는 형식입니다.", 400, "04006");
 
-    IMAGE_URL_INVALID("유요하지 않는 이미지 링크입니다.", 400, "04007"),
+//    IMAGE_INVALID("이미지 데이터가 아니거나, 유효하지 않은 이미지 링크입니다.", 400, "04007"),
 
-    IMAGE_UNREADABLE_URL("URL 형식이 아닙니다.", 400, "04008");
+//    IMAGE_UNREADABLE_URL("URL 형식이 아닙니다.", 400, "04008");
 
     private final String message;
     private final int status;

--- a/src/main/java/com/tourapi/mandi/global/util/UtilExceptionStatus.java
+++ b/src/main/java/com/tourapi/mandi/global/util/UtilExceptionStatus.java
@@ -1,0 +1,23 @@
+package com.tourapi.mandi.global.util;
+import com.tourapi.mandi.global.exception.BaseExceptionStatus;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UtilExceptionStatus implements BaseExceptionStatus {
+
+    NOT_BASE64_DATA("Base64 형식이 아닙니다.", 400, "04004"),
+    IMAGE_INVALID_DATA("유효하지 않은 이미지 데이터입니다.", 400, "04005"),
+
+    IMAGE_UNREADABLE_DATA("이미지가 손상되었거나 읽을 수 없는 형식입니다.", 400, "04006"),
+
+    IMAGE_URL_INVALID("유요하지 않는 이미지 링크입니다.", 400, "04007"),
+
+    IMAGE_UNREADABLE_URL("URL 형식이 아닙니다.", 400, "04008");
+
+    private final String message;
+    private final int status;
+    private final String errorCode;
+
+}


### PR DESCRIPTION
1. S3 Config와 Client를 구현, AWS의 버킷과 연동하는 기능을 구현하였습니다.
2. Security 관련 설정을 변경하였습니다(권한이 필요한 api와 필요없는 api 분리 및 그에 맞는 예외처리 등등)
3. BlackList기능을 구현하였습니다.
4.  처음 회원가입시 S3에 저장되어있는 디폴트이미지로 imgUrl저장됩니다.
5. 후에 프로필사진 변경시 변경된 이미지를 s3에 저장하고 해당 ImgUrl을 유저정보에 변경후에 return해줍니다.
6. 위 모든 기능들의 예외처리를 구현하였습니다.