### PR TITLE
Swagger API 문서 설정 추가 (Authorize 버튼, API 응답값 추가)

### DIFF
--- a/src/main/java/com/tourapi/mandi/domain/badge/controller/BadgeController.java
+++ b/src/main/java/com/tourapi/mandi/domain/badge/controller/BadgeController.java
@@ -4,6 +4,9 @@ import com.tourapi.mandi.domain.badge.dto.BadgeListResponseDto;
 import com.tourapi.mandi.domain.badge.service.BadgeService;
 import com.tourapi.mandi.global.util.ApiUtils;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,8 +26,13 @@ public class BadgeController {
     private final BadgeService badgeService;
 
     @Operation(summary = "배지 목록 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "배지 목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않은 사용자 ID 입력시")
+    })
     @GetMapping("/{userId}")
     public ResponseEntity<ApiUtils.ApiResult<BadgeListResponseDto>> googleLogin(
+            @Parameter(description = "사용자 ID", required = true)
             @PathVariable("userId") Long userId
     ) {
         BadgeListResponseDto resultDto = badgeService.getUserBadges(userId);

--- a/src/main/java/com/tourapi/mandi/domain/user/controller/LoginController.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/controller/LoginController.java
@@ -8,6 +8,10 @@ import com.tourapi.mandi.domain.user.service.UserService;
 import com.tourapi.mandi.global.util.ApiUtils;
 import com.tourapi.mandi.global.util.ApiUtils.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -27,11 +31,16 @@ public class LoginController {
     private final UserService userService;
 
     @Operation(summary = "구글 소셜 로그인")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 access token 입력시"),
+            @ApiResponse(responseCode = "500", description = "Google API 연동 중 문제 발생시"),
+    })
     @PostMapping("/google/login")
     public ResponseEntity<ApiResult<LoginResponseDto>> googleLogin(
             @NotBlank
             @RequestHeader(value = "Google")
-            String token
+            @Parameter(description = "Google access token", required = true) String token
     ) {
         GoogleUserInfo userInfo = googleService.getGoogleUserInfo(token);
         LoginResponseDto resultDto = userService.socialLogin(userInfo);
@@ -39,10 +48,16 @@ public class LoginController {
     }
 
     @Operation(summary = "구글 소셜 회원가입 ")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "400", description = "1. 유효하지 않은 access token 입력시\n2. 유효하지 않은 닉네임/한줄소개 입력시"),
+            @ApiResponse(responseCode = "500", description = "Google API 연동 중 문제 발생시"),
+    })
     @PostMapping("/google/signup")
     public ResponseEntity<ApiResult<LoginResponseDto>> googleSignup(
             @NotBlank
-            @RequestHeader(value = "Google") String token,
+            @RequestHeader(value = "Google")
+            @Parameter(description = "Google access token", required = true) String token,
             @RequestBody @Valid SignupRequestDto requestDto
     ) {
         GoogleUserInfo userInfo = googleService.getGoogleUserInfo(token);

--- a/src/main/java/com/tourapi/mandi/domain/user/controller/ProfileController.java
+++ b/src/main/java/com/tourapi/mandi/domain/user/controller/ProfileController.java
@@ -7,6 +7,8 @@ import com.tourapi.mandi.domain.user.service.ProfileService;
 import com.tourapi.mandi.global.security.CustomUserDetails;
 import com.tourapi.mandi.global.util.ApiUtils;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,10 @@ public class ProfileController {
     private final ProfileService profileService;
 
     @Operation(summary = "중복 닉네임 검증")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "중복되지 않은 닉네임"),
+            @ApiResponse(responseCode = "409", description = "중복된 닉네임 입력시")
+    })
     @PostMapping("/check-nickname")
     public ResponseEntity<ApiUtils.ApiResult<Boolean>> checkNicknameDuplication(
             @RequestBody @Valid NicknameValidationRequestDto requestDto
@@ -36,6 +42,11 @@ public class ProfileController {
     }
 
     @Operation(summary = "프로필 정보 변경(닉네임, 한줄소개)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "프로필 변경 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않은 사용자 정보 인증시"),
+            @ApiResponse(responseCode = "409", description = "중복된 닉네임 입력시")
+    })
     @PatchMapping("/info")
     public ResponseEntity<ApiUtils.ApiResult<Boolean>> updateProfile(
             @RequestBody @Valid ProfileUpdateRequestDto requestDto,
@@ -45,6 +56,11 @@ public class ProfileController {
     }
 
     @Operation(summary = "프로필 사진 변경")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "프로필 사진 변경 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않은 사용자 정보 인증시"),
+            @ApiResponse(responseCode = "400", description = "base64 형식으로 인코딩되지 프로필 사진 요청시")
+    })
     @PatchMapping("/img")
     public ResponseEntity<ApiUtils.ApiResult<String>> changeProfileImage(
             @RequestBody @Valid ProfileImageChangeRequestDto requestDto,

--- a/src/main/java/com/tourapi/mandi/global/config/OpenAPIConfig.java
+++ b/src/main/java/com/tourapi/mandi/global/config/OpenAPIConfig.java
@@ -31,9 +31,11 @@ public class OpenAPIConfig {
 
     private SecurityScheme jwtSecurityScheme() {
         return new SecurityScheme()
-                .type(SecurityScheme.Type.APIKEY)
+                .type(SecurityScheme.Type.HTTP)
                 .in(SecurityScheme.In.HEADER)
-                .name("Authorization");
+                .name("Authorization")
+                .scheme("Bearer")
+                .bearerFormat("JWT");
     }
 
     private SecurityRequirement bearerTokenRequirement() {

--- a/src/main/java/com/tourapi/mandi/global/config/OpenAPIConfig.java
+++ b/src/main/java/com/tourapi/mandi/global/config/OpenAPIConfig.java
@@ -1,18 +1,42 @@
 package com.tourapi.mandi.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 
 @Configuration
 public class OpenAPIConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .info(new Info()
-                        .title("만디 API 문서")
-                        .version("1.0.0")
-                );
+                .info(apiInfo())
+                .components(bearerTokenComponents())
+                .addSecurityItem(bearerTokenRequirement());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("만디 API 문서")
+                .version("1.0.0");
+    }
+
+    private Components bearerTokenComponents() {
+        return new Components().addSecuritySchemes("Bearer Token", jwtSecurityScheme());
+    }
+
+    private SecurityScheme jwtSecurityScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+    }
+
+    private SecurityRequirement bearerTokenRequirement() {
+        return new SecurityRequirement().addList("Bearer Token");
     }
 }

--- a/src/main/java/com/tourapi/mandi/global/config/OpenAPIConfig.java
+++ b/src/main/java/com/tourapi/mandi/global/config/OpenAPIConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -40,5 +41,29 @@ public class OpenAPIConfig {
 
     private SecurityRequirement bearerTokenRequirement() {
         return new SecurityRequirement().addList("Bearer Token");
+    }
+
+    @Bean
+    public GroupedOpenApi authOpenApi() {
+        return GroupedOpenApi.builder()
+                .group("로그인 API")
+                .pathsToMatch("/auth/**", "/dev/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi profileOpenApi() {
+        return GroupedOpenApi.builder()
+                .group("프로필 API")
+                .pathsToMatch("/profile/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi badgeOpenApi() {
+        return GroupedOpenApi.builder()
+                .group("뱃지 API")
+                .pathsToMatch("/badges/**")
+                .build();
     }
 }

--- a/src/main/java/com/tourapi/mandi/global/util/ApiUtils.java
+++ b/src/main/java/com/tourapi/mandi/global/util/ApiUtils.java
@@ -14,17 +14,17 @@ public class ApiUtils {
 
     @Schema(description = "정상 처리 시 응답 DTO")
     public record ApiResult<T>(
-            boolean success,
-            T response,
-            ApiError error
+            @Schema(description = "응답 성공 여부") boolean success,
+            @Schema(description = "응답 본문") T response,
+            @Schema(description = "에러 발생시 상세 기재", nullable = true) ApiError error
     ) {
     }
 
     @Schema(description = "에러 발생 시 응답 DTO")
     public record ApiError(
-            String message,
-            int status,
-            String errorCode
+            @Schema(description = "오류 메시지") String message,
+            @Schema(description = "HTTP 상태 코드") int status,
+            @Schema(description = "애러 코드") String errorCode
     ) {
     }
 }


### PR DESCRIPTION
## 개요
API 문서에 실패에 대한 응답 코드와 인증 기능을 위한 Authorize 버튼을 추가했습니다.
개발 서버에도 반영해두었으니 확인 부탁드립니다 :)

> [개발 서버 바로가기](http://ec2-15-165-181-58.ap-northeast-2.compute.amazonaws.com:8080/mandi/swagger-ui/swagger-ui/index.html)

## 관련 이슈
#18