### PR TITLE
#28 docs: 좌표 기반 영역 검색 api 설정 수정

### DIFF
--- a/src/main/java/com/tourapi/mandi/domain/course/dto/CourseNearbyRequestDto.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/dto/CourseNearbyRequestDto.java
@@ -3,9 +3,8 @@ package com.tourapi.mandi.domain.course.dto;
 import com.tourapi.mandi.domain.course.entity.Coordinate;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import org.springdoc.core.annotations.ParameterObject;
 
-@ParameterObject
+@Schema(description = "좌표 기반 영역 검색 요청 DTO")
 public record CourseNearbyRequestDto(
 
         @NotNull(message = "좌표는 필수 입력 사항입니다.")


### PR DESCRIPTION
- 쿼리 파라미터 대신 post 요청의 본문으로 조회할 수 있도록 구조를 수정