### PR TITLE
완주 코스 목록 조회 API 필드 추가

### DIFF
--- a/src/main/java/com/tourapi/mandi/domain/course/dto/CompletedCourseDto.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/dto/CompletedCourseDto.java
@@ -2,7 +2,6 @@ package com.tourapi.mandi.domain.course.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
@@ -12,6 +11,9 @@ public record CompletedCourseDto(
 
         @Schema(description = "완주 코스 이름")
         String courseName,
+
+        @Schema(description = "코스 완주 소요 시간")
+        String duration,
 
         @Schema(description = "완주 코스 거리")
         BigDecimal distance,

--- a/src/main/java/com/tourapi/mandi/domain/course/dto/CompletedCourseDto.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/dto/CompletedCourseDto.java
@@ -18,6 +18,9 @@ public record CompletedCourseDto(
         @Schema(description = "완주 코스 거리")
         BigDecimal distance,
 
+        @Schema(description = "코스 트레킹 경로 이미지 URL")
+        String trekkingPathImageUrl,
+
         @Schema(description = "코스 완주 일시")
         String completedAt
 ) {

--- a/src/main/java/com/tourapi/mandi/domain/course/dto/CompletedCourseDto.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/dto/CompletedCourseDto.java
@@ -19,6 +19,6 @@ public record CompletedCourseDto(
         BigDecimal distance,
 
         @Schema(description = "코스 완주 일시")
-        LocalDateTime completedAt
+        String completedAt
 ) {
 }

--- a/src/main/java/com/tourapi/mandi/domain/course/dto/ReviewDto.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/dto/ReviewDto.java
@@ -1,7 +1,6 @@
 package com.tourapi.mandi.domain.course.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
@@ -19,6 +18,6 @@ public record ReviewDto(
         Integer score,
 
         @Schema(description = "후기 작성 일시")
-        LocalDateTime reviewedAt
+        String reviewedAt
 ) {
 }

--- a/src/main/java/com/tourapi/mandi/domain/course/entity/CompletedCourse.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/entity/CompletedCourse.java
@@ -36,6 +36,9 @@ public class CompletedCourse extends AuditingEntity {
     @JoinColumn(name = "course_id", nullable = false)
     private Course course;
 
+    @Column(nullable = false, precision = 6, scale = 3)
+    private BigDecimal distance;
+
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @Column(nullable = false)
     private LocalDateTime startedAt;

--- a/src/main/java/com/tourapi/mandi/domain/course/entity/CompletedCourse.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/entity/CompletedCourse.java
@@ -39,6 +39,9 @@ public class CompletedCourse extends AuditingEntity {
     @Column(nullable = false, precision = 6, scale = 3)
     private BigDecimal distance;
 
+    @Column(length = 512, nullable = false)
+    private String trekkingPathImageUrl;
+
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @Column(nullable = false)
     private LocalDateTime startedAt;

--- a/src/main/java/com/tourapi/mandi/domain/course/entity/CompletedCourse.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/entity/CompletedCourse.java
@@ -11,7 +11,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,12 +29,20 @@ public class CompletedCourse extends AuditingEntity {
     private Long completedCourseId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id")
+    @JoinColumn(name = "course_id", nullable = false)
     private Course course;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @Column(nullable = false)
+    private LocalDateTime startedAt;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @Column(nullable = false)
+    private LocalDateTime completedAt;
 
     @Column(nullable = false)
     private Boolean isReviewed;
@@ -43,4 +53,23 @@ public class CompletedCourse extends AuditingEntity {
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime reviewedAt;
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        CompletedCourse other = (CompletedCourse) obj;
+        return Objects.equals(getCompletedCourseId(), other.getCompletedCourseId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getCompletedCourseId());
+    }
 }

--- a/src/main/java/com/tourapi/mandi/domain/course/service/CompletedCourseService.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/service/CompletedCourseService.java
@@ -35,7 +35,7 @@ public class CompletedCourseService  {
 
         for (final CompletedCourse completedCourse : completedCourses) {
             completedCourseDtos.add(CompletedCourseMapper.toCompletedCourseDto(completedCourse));
-            totalDistance = totalDistance.add(completedCourse.getCourse().getDistance());
+            totalDistance = totalDistance.add(completedCourse.getDistance());
         }
 
        return  CompletedCourseMapper.toCompletedCourseListResponseDto(

--- a/src/main/java/com/tourapi/mandi/domain/course/util/CompletedCourseMapper.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/util/CompletedCourseMapper.java
@@ -20,6 +20,7 @@ public final class CompletedCourseMapper {
                 .courseName(completedCourse.getCourse().getName())
                 .duration(DateTimeUtil.formatDuration(duration))
                 .distance(completedCourse.getDistance())
+                .trekkingPathImageUrl(completedCourse.getTrekkingPathImageUrl())
                 .completedAt(DateTimeUtil.formatDate(completedCourse.getCompletedAt()))
                 .build();
     }

--- a/src/main/java/com/tourapi/mandi/domain/course/util/CompletedCourseMapper.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/util/CompletedCourseMapper.java
@@ -3,6 +3,7 @@ package com.tourapi.mandi.domain.course.util;
 import com.tourapi.mandi.domain.course.dto.CompletedCourseDto;
 import com.tourapi.mandi.domain.course.dto.CompletedCourseListResponseDto;
 import com.tourapi.mandi.domain.course.entity.CompletedCourse;
+import java.time.Duration;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -12,9 +13,12 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CompletedCourseMapper {
     public static CompletedCourseDto toCompletedCourseDto(CompletedCourse completedCourse) {
+        Duration duration = Duration.between(completedCourse.getStartedAt(), completedCourse.getCompletedAt());
+
         return CompletedCourseDto.builder()
                 .id(completedCourse.getCompletedCourseId())
                 .courseName(completedCourse.getCourse().getName())
+                .duration(DateTimeUtil.formatDuration(duration))
                 .distance(completedCourse.getCourse().getDistance())
                 .completedAt(completedCourse.getCreatedAt())
                 .build();

--- a/src/main/java/com/tourapi/mandi/domain/course/util/CompletedCourseMapper.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/util/CompletedCourseMapper.java
@@ -20,7 +20,7 @@ public final class CompletedCourseMapper {
                 .courseName(completedCourse.getCourse().getName())
                 .duration(DateTimeUtil.formatDuration(duration))
                 .distance(completedCourse.getCourse().getDistance())
-                .completedAt(completedCourse.getCreatedAt())
+                .completedAt(DateTimeUtil.formatDate(completedCourse.getCreatedAt()))
                 .build();
     }
 

--- a/src/main/java/com/tourapi/mandi/domain/course/util/CompletedCourseMapper.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/util/CompletedCourseMapper.java
@@ -19,8 +19,8 @@ public final class CompletedCourseMapper {
                 .id(completedCourse.getCompletedCourseId())
                 .courseName(completedCourse.getCourse().getName())
                 .duration(DateTimeUtil.formatDuration(duration))
-                .distance(completedCourse.getCourse().getDistance())
-                .completedAt(DateTimeUtil.formatDate(completedCourse.getCreatedAt()))
+                .distance(completedCourse.getDistance())
+                .completedAt(DateTimeUtil.formatDate(completedCourse.getCompletedAt()))
                 .build();
     }
 

--- a/src/main/java/com/tourapi/mandi/domain/course/util/DateTimeUtil.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/util/DateTimeUtil.java
@@ -1,0 +1,15 @@
+package com.tourapi.mandi.domain.course.util;
+
+import java.time.Duration;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DateTimeUtil {
+    public static String formatDuration(Duration duration) {
+        long hours = duration.toHours();
+        long minutes = duration.toMinutes() % 60;
+
+        return String.format("%d:%02d", hours, minutes);
+    }
+}

--- a/src/main/java/com/tourapi/mandi/domain/course/util/DateTimeUtil.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/util/DateTimeUtil.java
@@ -1,15 +1,23 @@
 package com.tourapi.mandi.domain.course.util;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DateTimeUtil {
+    private static final DateTimeFormatter defaultFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
     public static String formatDuration(Duration duration) {
         long hours = duration.toHours();
         long minutes = duration.toMinutes() % 60;
 
         return String.format("%d:%02d", hours, minutes);
+    }
+
+    public static String formatDate(LocalDateTime date) {
+        return date.format(defaultFormatter);
     }
 }

--- a/src/main/java/com/tourapi/mandi/domain/course/util/ReviewMapper.java
+++ b/src/main/java/com/tourapi/mandi/domain/course/util/ReviewMapper.java
@@ -21,7 +21,7 @@ public final class ReviewMapper {
                 .isReviewed(completedCourse.getIsReviewed())
                 .content(completedCourse.getReviewContent())
                 .score(completedCourse.getReviewScore())
-                .reviewedAt(completedCourse.getReviewedAt())
+                .reviewedAt(DateTimeUtil.formatDate(completedCourse.getReviewedAt()))
                 .build();
     }
 

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -118,14 +118,14 @@ VALUES (1, 'Namparang Trail Course 1', 19.0, 'Moderate', '7h', 'https://shorturl
         'Haeundae-gu', 'Busan', 35.158975124359124, 129.16027123108506,
         now(), now());
 
-INSERT INTO completed_course_tb(completed_course_id, user_id, course_id, distance, is_reviewed, review_content,
-                                review_score, reviewed_at, started_at, completed_at, created_at, last_modified_at)
-VALUES (1, 3, 1, 0.875, 1, 'good', 5, now(), DATEADD('MINUTE', -35, now()), now(), now(), now()),
-       (2, 3, 2, 1.23, 1, 'nice', 4, now(), DATEADD('MINUTE', -60, now()), now(), now(), now()),
-       (3, 3, 3, 2.7, 0, null, null, null, DATEADD('MINUTE', -84, now()), now(), now(), now()),
-       (4, 4, 4, 0.875, 1, 'good', 5, now(), DATEADD('MINUTE', -27, now()), now(), now(), now()),
-       (5, 4, 5, 1.23, 1, 'nice', 4, now(), DATEADD('MINUTE', -60, now()), now(), now(), now()),
-       (6, 4, 6, 4.0, 0, null, null, null, DATEADD('MINUTE', -72, now()), now(), now(), now())
+INSERT INTO completed_course_tb(completed_course_id, user_id, course_id, distance, trekking_path_image_url, is_reviewed,
+                                review_content, review_score, reviewed_at, started_at, completed_at, created_at, last_modified_at)
+VALUES (1, 3, 1, 0.875, 'https://github.com/user-attachments/assets/03fea9d2-c196-4a8a-84e0-4e10c36ecfc6', 1, 'good', 5, now(), DATEADD('MINUTE', -35, now()), now(), now(), now()),
+       (2, 3, 2, 1.23, 'https://github.com/user-attachments/assets/03fea9d2-c196-4a8a-84e0-4e10c36ecfc6', 1, 'nice', 4, now(), DATEADD('MINUTE', -60, now()), now(), now(), now()),
+       (3, 3, 3, 2.7, 'https://github.com/user-attachments/assets/03fea9d2-c196-4a8a-84e0-4e10c36ecfc6', 0, null, null, null, DATEADD('MINUTE', -84, now()), now(), now(), now()),
+       (4, 4, 4, 0.875, 'https://github.com/user-attachments/assets/03fea9d2-c196-4a8a-84e0-4e10c36ecfc6', 1, 'good', 5, now(), DATEADD('MINUTE', -27, now()), now(), now(), now()),
+       (5, 4, 5, 1.23, 'https://github.com/user-attachments/assets/03fea9d2-c196-4a8a-84e0-4e10c36ecfc6', 1, 'nice', 4, now(), DATEADD('MINUTE', -60, now()), now(), now(), now()),
+       (6, 4, 6, 4.0, 'https://github.com/user-attachments/assets/03fea9d2-c196-4a8a-84e0-4e10c36ecfc6', 0, null, null, null, DATEADD('MINUTE', -72, now()), now(), now(), now())
 ;
 
 -- 기본 댓글 (parent_comment_id가 NULL)

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -118,14 +118,14 @@ VALUES (1, 'Namparang Trail Course 1', 19.0, 'Moderate', '7h', 'https://shorturl
         'Haeundae-gu', 'Busan', 35.158975124359124, 129.16027123108506,
         now(), now());
 
-INSERT INTO completed_course_tb(completed_course_id, user_id, course_id, is_reviewed, review_content, review_score,
-                                reviewed_at, created_at, last_modified_at)
-VALUES (1, 3, 1, 1, 'good', 5, now(), now(), now()),
-       (2, 3, 2, 1, 'nice', 4, now(), now(), now()),
-       (3, 3, 3, 0, null, null, null, now(), now()),
-       (4, 4, 4, 1, 'good', 5, now(), now(), now()),
-       (5, 4, 5, 1, 'nice', 4, now(), now(), now()),
-       (6, 4, 6, 0, null, null, null, now(), now())
+INSERT INTO completed_course_tb(completed_course_id, user_id, course_id, distance, is_reviewed, review_content,
+                                review_score, reviewed_at, started_at, completed_at, created_at, last_modified_at)
+VALUES (1, 3, 1, 0.875, 1, 'good', 5, now(), DATEADD('MINUTE', -35, now()), now(), now(), now()),
+       (2, 3, 2, 1.23, 1, 'nice', 4, now(), DATEADD('MINUTE', -60, now()), now(), now(), now()),
+       (3, 3, 3, 2.7, 0, null, null, null, DATEADD('MINUTE', -84, now()), now(), now(), now()),
+       (4, 4, 4, 0.875, 1, 'good', 5, now(), DATEADD('MINUTE', -27, now()), now(), now(), now()),
+       (5, 4, 5, 1.23, 1, 'nice', 4, now(), DATEADD('MINUTE', -60, now()), now(), now(), now()),
+       (6, 4, 6, 4.0, 0, null, null, null, DATEADD('MINUTE', -72, now()), now(), now(), now())
 ;
 
 -- 기본 댓글 (parent_comment_id가 NULL)


### PR DESCRIPTION
1. 소요 시간(duration) 필드 추가
2. 코스 엔티티 자체의 거리 대신 유저가 완주한 거리 값으로 교체
3. 완주 시각, 후기 작성 시각 형식 수정
4. 트레킹 경로 이미지 필드 추가